### PR TITLE
add withHostname, withName, withLabels support

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -32,16 +32,6 @@ class Container extends GenericContainer
     }
 
     /**
-     * @deprecated Use `withEntrypoint` instead
-     * TODO: this is just dummy method for compatibility,
-     * the implementation with Docker Engine API should be discussed
-     */
-    public function withHostname(string $hostname): self
-    {
-        return $this;
-    }
-
-    /**
      * @deprecated Use `withPrivilegedMode` instead
      */
     public function withPrivileged(bool $privileged = true): self

--- a/src/Container/GenericContainer.php
+++ b/src/Container/GenericContainer.php
@@ -33,7 +33,7 @@ class GenericContainer implements TestContainer
 
     /**
      * User-defined key/value metadata.
-     * @param array<string, string>|null $labels
+     * @var array<string, string>|null $labels
      */
     protected ?array $labels = null;
 

--- a/src/Container/StartedGenericContainer.php
+++ b/src/Container/StartedGenericContainer.php
@@ -23,7 +23,6 @@ class StartedGenericContainer implements StartedTestContainer
         $this->dockerClient = DockerContainerClient::getDockerClient();
     }
 
-
     public function getId(): string
     {
         return $this->id;

--- a/src/Container/StartedTestContainer.php
+++ b/src/Container/StartedTestContainer.php
@@ -8,36 +8,36 @@ use Docker\Docker;
 
 interface StartedTestContainer
 {
-    public function stop(): StoppedTestContainer;
-
-    public function restart(): self;
-
-    public function getClient(): Docker;
-
-    public function getHost(): string;
-
-    public function getFirstMappedPort(): int;
-
-    public function getMappedPort(int $port): int;
-
-    public function getName(): string;
-
-    public function getLabels(): array;
-
-    public function getId(): string;
-
-    public function getLastExecId(): string | null;
-
-    public function getNetworkNames(): array;
-
-    public function getNetworkId(string $networkName): string;
-
-    public function getIpAddress(string $networkName): string;
-
     /**
      * @param list<string> $command
      */
     public function exec(array $command): string;
 
+    public function getClient(): Docker;
+
+    public function getFirstMappedPort(): int;
+
+    public function getHost(): string;
+
+    public function getId(): string;
+
+    public function getIpAddress(string $networkName): string;
+
+    public function getLabels(): array;
+
     public function logs(): string;
+
+    public function getLastExecId(): string | null;
+
+    public function getMappedPort(int $port): int;
+
+    public function getName(): string;
+
+    public function getNetworkId(string $networkName): string;
+
+    public function getNetworkNames(): array;
+
+    public function restart(): self;
+
+    public function stop(): StoppedTestContainer;
 }

--- a/src/Container/TestContainer.php
+++ b/src/Container/TestContainer.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace Testcontainers\Container;
 
+use Testcontainers\Utils\PortGenerator\PortGenerator;
 use Testcontainers\Wait\WaitStrategy;
 
 interface TestContainer
 {
     public function start(): StartedGenericContainer;
-
-    /**
-     * TODO: replace with array after deprecated implementation is removed
-     * @param array<string, string>|string $env
-     */
-    public function withEnvironment(array | string $env, ?string $value): static;
 
     /**
      * @param array<string> $command
@@ -23,12 +18,39 @@ interface TestContainer
 
     public function withEntrypoint(string $entryPoint): static;
 
+    /**
+     * TODO: replace with array after deprecated implementation is removed
+     * @param array<string, string>|string $env
+     */
+    public function withEnvironment(array | string $env, ?string $value): static;
+
     /**  @param int|string|array<int|string> $ports One or more ports to expose. */
     public function withExposedPorts(...$ports): static;
 
-    public function withWait(WaitStrategy $waitStrategy): static;
+    public function withHealthCheckCommand(
+        string $command,
+        int $intervalInMilliseconds,
+        int $timeoutInMilliseconds,
+        int $retries,
+        int $startPeriodInMilliseconds
+    ): static;
+
+    public function withHostname(string $hostname): static;
+
+    /**
+     * @param array<string, string> $labels
+     */
+    public function withLabels(array $labels): static;
+
+    public function withMount(string $localPath, string $containerPath): static;
+
+    public function withName(string $name): static;
 
     public function withNetwork(string $networkName): static;
 
-    public function withPrivilegedMode(): static;
+    public function withPortGenerator(PortGenerator $portGenerator): static;
+
+    public function withPrivilegedMode(bool $privileged): static;
+
+    public function withWait(WaitStrategy $waitStrategy): static;
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/Container` directory, primarily focusing on enhancing the `GenericContainer` class and removing deprecated methods. The most important changes include the addition of new properties and methods to manage container metadata and the removal of a deprecated method from the `Container` class.

Enhancements to `GenericContainer` class:

* [`src/Container/GenericContainer.php`](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR32-R41): Added new properties `name`, `labels`, and `hostname` to manage container metadata.
* [`src/Container/GenericContainer.php`](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR153-R166): Added methods `withHostname`, `withName`, and `withLabels` to set the newly added properties. [[1]](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR153-R166) [[2]](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR194-R210)
* [`src/Container/GenericContainer.php`](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR237-R243): Updated the `start` method to include `name` in the query parameters when creating a container.
* [`src/Container/GenericContainer.php`](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edR268-R269): Updated the `createContainerConfig` method to set the `labels` and `hostname` properties in the container configuration.

Removal of deprecated method:

* [`src/Container/Container.php`](diffhunk://#diff-b3061446b6923316c68d46e450315e4a900b1fd223576d2bafa009bbd417f97eL34-L43): Removed the deprecated `withHostname` method.