### PR TITLE
Fix #35 fails when run container using withNetwork()

### DIFF
--- a/src/Container/GenericContainer.php
+++ b/src/Container/GenericContainer.php
@@ -411,9 +411,12 @@ class GenericContainer implements TestContainer
 
         if ($this->networkName !== null) {
             $networkingConfig = new NetworkingConfig();
-            $endpointsConfig = new \ArrayObject([
-                $this->networkName => new EndpointSettings(),
-            ]);
+            $endpointsConfig = [
+                $this->networkName => new EndpointSettings([
+                    'networkID' => $this->networkName,
+                    'aliases' => $this->name ? [$this->name] : [],
+                ]),
+            ];
             $networkingConfig->setEndpointsConfig($endpointsConfig);
             $containerCreatePostBody->setNetworkingConfig($networkingConfig);
         }


### PR DESCRIPTION
This pull request includes an important change to the `createContainerConfig` method in the `GenericContainer` class. The change involves modifying the way `endpointsConfig` is created, enhancing the configuration by adding network ID and aliases. Fixes #35 

Networking configuration enhancement:

* [`src/Container/GenericContainer.php`](diffhunk://#diff-3f8ad8afacf1a69d935de2d29187e723aac37312c6a4be59b7debe2454e0e8edL414-R419): Modified the `createContainerConfig` method to create `endpointsConfig` using an array with network ID and aliases instead of an `ArrayObject`.