### PR TITLE
Support for dynamic port for WaitForHttp.php

### DIFF
--- a/src/Container/StartedGenericContainer.php
+++ b/src/Container/StartedGenericContainer.php
@@ -198,6 +198,13 @@ class StartedGenericContainer implements StartedTestContainer
      */
     public function getBoundPorts(): iterable
     {
+        /**
+         * For some reason, in the latest Docker releases, at this moment, the container might not be fully started.
+         * This can lead to issues when trying to retrieve the ports.
+         * TODO: find a better strategy to ensure the container is fully started or run in a loop until it is ready.
+         * For the loop $this->inspect() shouldn't be cached.
+         */
+        usleep(300 * 1000);
         $ports = $this->inspect()?->getNetworkSettings()?->getPorts();
 
         if ($ports === null) {


### PR DESCRIPTION
- Added support for dynamic port for WaitForHttp.php
This pull request introduces changes to improve container startup reliability and enhance the HTTP wait strategy in the codebase. Key updates include adding a delay to ensure containers are fully started, making the HTTP wait strategy more robust by handling dynamic port resolution and exceptions, and minor adjustments to improve code clarity.

### Container Startup Reliability:
* Added a 300ms delay in the `getBoundPorts` method of `StartedGenericContainer` to address potential issues with containers not being fully started in recent Docker releases. A TODO comment suggests finding a better long-term solution. (`src/Container/StartedGenericContainer.php`, [src/Container/StartedGenericContainer.phpR201-R207](diffhunk://#diff-267eca061c4b339270a80ca2152c4caac0d8fcc3e3cee07e6a1f3efbb0ddbab7R201-R207))

### HTTP Wait Strategy Enhancements:
* Updated the `WaitForHttp` class to allow the `port` parameter to be nullable, enabling dynamic port resolution. (`src/Wait/WaitForHttp.php`, [src/Wait/WaitForHttp.phpL34-R34](diffhunk://#diff-cf8f57e5a397b09a9af66563382a627a297fd108fc9e0b140f74f16ec649772aL34-R34))
* Introduced a `resolvePort` method in `WaitForHttp` to dynamically determine the port if not explicitly provided. This method is invoked in the `wait` method. (`src/Wait/WaitForHttp.php`, [[1]](diffhunk://#diff-cf8f57e5a397b09a9af66563382a627a297fd108fc9e0b140f74f16ec649772aR147-R153) [[2]](diffhunk://#diff-cf8f57e5a397b09a9af66563382a627a297fd108fc9e0b140f74f16ec649772aR103-R104)
* Added exception handling in the `wait` method to gracefully retry on port resolution or HTTP request failures until the timeout is reached. (`src/Wait/WaitForHttp.php`, [src/Wait/WaitForHttp.phpR113-R115](diffhunk://#diff-cf8f57e5a397b09a9af66563382a627a297fd108fc9e0b140f74f16ec649772aR113-R115))

### Minor Improvements:
* Corrected a comment in the `makeHttpRequest` method for consistency and clarity. (`src/Wait/WaitForHttp.php`, [src/Wait/WaitForHttp.phpL123-R128](diffhunk://#diff-cf8f57e5a397b09a9af66563382a627a297fd108fc9e0b140f74f16ec649772aL123-R128))
- Tmp fix for getBoundPorts() strange fails on the latest Docker releases.