### PR TITLE
feat: add support for tmpfs mounts in GenericContainer

### DIFF
--- a/src/Container/GenericContainer.php
+++ b/src/Container/GenericContainer.php
@@ -96,6 +96,9 @@ class GenericContainer implements TestContainer
      */
     protected array $mounts = [];
 
+    /** @var array<string, string> */
+    protected array $tmpfs = [];
+
     /** @var array<string> List of exposed ports in the format ['8080/tcp'] */
     protected array $exposedPorts = [];
 
@@ -217,6 +220,13 @@ class GenericContainer implements TestContainer
             'source' => $localPath,
             'target' => $containerPath,
         ]);
+
+        return $this;
+    }
+
+    public function withTmpfs(string $containerPath, string $options = 'rw,noexec'): static
+    {
+        $this->tmpfs[$containerPath] = $options;
 
         return $this;
     }
@@ -458,7 +468,7 @@ class GenericContainer implements TestContainer
          * the API will throw ContainerCreateBadRequestException: bad parameter.
          * Until it will be checked and fixed, we just return null if these properties are not set.
          * */
-        if ($this->exposedPorts === [] && !$this->isPrivileged && $this->mounts === []) {
+        if ($this->exposedPorts === [] && !$this->isPrivileged && $this->mounts === [] && $this->tmpfs === []) {
             return null;
         }
 
@@ -477,6 +487,10 @@ class GenericContainer implements TestContainer
 
         if ($this->mounts !== []) {
             $hostConfig->setMounts($this->mounts);
+        }
+
+        if ($this->tmpfs !== []) {
+            $hostConfig->setTmpfs($this->tmpfs);
         }
 
         return $hostConfig;

--- a/src/Container/TestContainer.php
+++ b/src/Container/TestContainer.php
@@ -43,6 +43,8 @@ interface TestContainer
 
     public function withMount(string $localPath, string $containerPath): static;
 
+    public function withTmpfs(string $containerPath, string $options = 'rw,noexec'): static;
+
     public function withName(string $name): static;
 
     public function withNetwork(string $networkName): static;

--- a/tests/Integration/GenericContainerTest.php
+++ b/tests/Integration/GenericContainerTest.php
@@ -291,6 +291,19 @@ class GenericContainerTest extends TestCase
         $container->stop();
     }
 
+    public function testShouldSetTmpfs(): void
+    {
+        $container = (new GenericContainer('alpine'))
+            ->withTmpfs('/mnt/tmpfs')
+            ->withCommand(['tail', '-f', '/dev/null'])
+            ->start();
+
+        $result = $container->exec(['cat', '/proc/mounts']);
+        self::assertStringContainsString('tmpfs /mnt/tmpfs', $result);
+
+        $container->stop();
+    }
+
     public function testShouldSetPrivilegedMode(): void
     {
         $container = (new GenericContainer('alpine'))

--- a/tests/Integration/GenericContainerTest.php
+++ b/tests/Integration/GenericContainerTest.php
@@ -298,8 +298,8 @@ class GenericContainerTest extends TestCase
             ->withCommand(['tail', '-f', '/dev/null'])
             ->start();
 
-        $result = $container->exec(['cat', '/proc/mounts']);
-        self::assertStringContainsString('tmpfs /mnt/tmpfs', $result);
+        $result = $container->exec(['stat', '-f', '-c', '%T', '/mnt/tmpfs']);
+        self::assertSame('tmpfs', $result);
 
         $container->stop();
     }


### PR DESCRIPTION
## Summary
- Adds `withTmpfs(string $containerPath, string $options = 'rw,noexec')` to `GenericContainer` and `TestContainer` interface
- Configures tmpfs mounts via Docker `HostConfig` when creating containers
- Includes integration test verifying tmpfs is mounted correctly

## Test plan
- [x] Integration test `testShouldSetTmpfs` added — starts an Alpine container with a tmpfs mount and verifies it appears in `/proc/mounts`