### PR TITLE
Copy files before starting container

### DIFF
--- a/src/Container/GenericContainer.php
+++ b/src/Container/GenericContainer.php
@@ -338,11 +338,11 @@ class GenericContainer implements TestContainer
             return $this->start();
         }
 
-        $this->dockerClient->containerStart($this->id);
-
         if ($this->filesToCopy !== [] || $this->directoriesToCopy !== [] || $this->contentsToCopy !== []) {
             $this->copyToContainer();
         }
+
+        $this->dockerClient->containerStart($this->id);
 
         $startedContainer = new StartedGenericContainer($this->id);
         $this->waitStrategy->wait($startedContainer);


### PR DESCRIPTION
Move the copy-to-container step before containerStart() so files configured with withCopyFilesToContainer(), withCopyDirectoriesToContainer(), or withCopyContentToContainer() are available when the container entrypoint starts.

This avoids races for images that read configuration immediately on startup, such as Caddy loading /etc/caddy/Caddyfile before the test-provided file has been copied into the container.